### PR TITLE
Issue 82 nmap output not saved

### DIFF
--- a/celerystalk
+++ b/celerystalk
@@ -82,7 +82,7 @@ import csv
 
 from lib.nmap import nmapcommand
 
-build=str(163)
+build=str(166)
 
 def print_banner():
 

--- a/lib/nmap.py
+++ b/lib/nmap.py
@@ -29,9 +29,9 @@ def nmap_scan_subdomain_host(vhost,workspace,simulation,output_base_dir,config_f
         cmd_name = "nmap_tcp_scan"
         try:
             if not simulation:
-                populated_command = "nmap " + vhost + config_nmap_options + " -oN " + output_file
+                populated_command = "nmap " + vhost + config_nmap_options + " -oA " + output_file
             else:
-                populated_command = "#nmap " + vhost + config_nmap_options + " -oN " + output_file
+                populated_command = "#nmap " + vhost + config_nmap_options + " -oA " + output_file
         except TypeError:
             print("[!] Error: In the config file, there needs to be one, and only one, enabled tcp_scan command in the nmap_commands section.")
             print("[!]        This determines what ports to scan.")

--- a/lib/nmap.py
+++ b/lib/nmap.py
@@ -17,7 +17,13 @@ def nmap_scan_subdomain_host(vhost,workspace,simulation,output_base_dir,config_f
     config.read(['config.ini'])
 
     vhost_explicitly_out_of_scope = lib.db.is_vhost_explicitly_out_of_scope(vhost, workspace)
-    output_file = os.path.normpath(os.path.join(output_base_dir, vhost,vhost + "_nmap_tcp_scan.txt"))
+    output_host_dir = os.path.normpath(os.path.join(output_base_dir, vhost))
+    try:
+        os.stat(output_host_dir)
+    except:
+        os.makedirs(output_host_dir)
+
+    output_file = os.path.normpath(os.path.join(output_host_dir, vhost + "_nmap_tcp_scan.txt"))
     if not vhost_explicitly_out_of_scope:
         #print(config_nmap_options)
         cmd_name = "nmap_tcp_scan"


### PR DESCRIPTION
Issue #82 notes that ./celerystalk nmap command is not saving the nmap output to disk because the full path was not created.  This PR adds a check to nmap.py to make sure the per vhost directory is created before it does anything else. 