### PR TITLE
As a user I want to run celerystalk from my current working directory.

### DIFF
--- a/celerystalk
+++ b/celerystalk
@@ -131,7 +131,10 @@ def main(arguments):
             print("[!] The specified config file does not exist. Try again?")
             exit()
     else:
-        config_file = 'config.ini'
+        config_file = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            'config.ini'
+        )
 
 
     ####################################

--- a/lib/db.py
+++ b/lib/db.py
@@ -1,7 +1,14 @@
+import os
 import sqlite3
 from sqlite3 import Error
 
-CONNECTION = sqlite3.connect("csdb.sqlite3")
+CONNECTION = sqlite3.connect(
+    os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "..",
+        "csdb.sqlite3"
+    )
+)
 CUR = CONNECTION.cursor()
 
 #############################

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -268,7 +268,7 @@ def create_task(command_name, populated_command, ip, output_dir, workspace, task
 def check_for_new_default_config():
 
     user_config_file = check_if_config_ini_exists()
-    default_config_file = 'setup/config_default.ini'
+    default_config_file = get_default_config_path()
     user_config_age=os.path.getmtime(user_config_file)
     #print(user_config_age)
     default_config_age = os.path.getmtime(default_config_file)
@@ -294,16 +294,29 @@ def check_for_new_default_config():
             p = Popen(populated_command, shell=True)
             p.communicate()
 
-
+def get_root_dir():
+    return os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        '..'
+    )
 
 def check_if_config_ini_exists():
-    if os.path.exists(os.path.join(os.getcwd(), 'config.ini')):
-        config_file = 'config.ini'
+    config_path = os.path.join(
+        get_root_dir(),
+        'config.ini'
+    )
+    if os.path.exists(config_path):
+        return config_path
     else:
         print("[!] The default config file does not exist. Run ./setup/install.sh and try again.")
         exit()
-    return config_file
 
+def get_default_config_path():
+    return os.path.join(
+        get_root_dir(),
+        'setup',
+        'config_default.ini'
+    )
 
 def check_for_dependencies():
     try:


### PR DESCRIPTION
Hi Seth!
First of all thanks for your effort on this tool, I find automation of tasks of discovery / info gathering phase super useful, and I'm looking forward to adding celerystalk to my default toolset.

One of the first things I noticed is I wasn't able to run celerystalk from my current workdir (if it's not the install dir) due hardcoded relative paths.
Even though this PR is not an "enterprise-grade" one (I'd still approach relative paths in a more controlled way), it immediately **allows users to put `celerystalk` into `$PATH` and run from whatever directory** they're currently in.

```
# cd /opt
# git clone https://github.com/sethsec/celerystalk.git
# cd celerystalk/setup
# .install.sh
# ln -s /opt/celerystalk/celerystalk /usr/bin/celerystalk
```

I don't know fully the features of celerystalk yet, so I only just tested this with
```
# cd /root
# celerystalk db workspace
# celerystalk workspace create/swith
# celerystalk scan
```

I'd be happy to contribute more if you find this useful.